### PR TITLE
Avoid DeprecationWarning from invalid escape sequences in docstring

### DIFF
--- a/parse.py
+++ b/parse.py
@@ -431,7 +431,7 @@ log = logging.getLogger(__name__)
 
 
 def with_pattern(pattern, regex_group_count=None):
-    """Attach a regular expression pattern matcher to a custom type converter
+    r"""Attach a regular expression pattern matcher to a custom type converter
     function.
 
     This annotates the type converter with the :attr:`pattern` attribute.


### PR DESCRIPTION
That docstring was triggering warnings.

```
=============================================================================================================== warnings summary ================================================================================================================
.venv/lib64/python3.6/site-packages/parse.py:454: DeprecationWarning: invalid escape sequence \d
    """

-- Docs: https://docs.pytest.org/en/latest/warnings.html

----------- coverage: platform linux, python 3.6.5-final-0 -----------
Coverage HTML written to dir htmlcov


```